### PR TITLE
send commands to 0x7e4 since we only listen for 0x7ec

### DIFF
--- a/app/www/components/cars/IONIQ_BEV.vue
+++ b/app/www/components/cars/IONIQ_BEV.vue
@@ -8,7 +8,7 @@
         data() {
             return {
                 initCMD: [
-                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'AT0', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC'
+                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'AT0', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC', 'ATTA7E4'
                 ],
                 offset: 0,
                 inStandbyMode: false,

--- a/app/www/components/cars/IONIQ_HEV.vue
+++ b/app/www/components/cars/IONIQ_HEV.vue
@@ -8,7 +8,7 @@
         data() {
             return {
                 initCMD: [
-                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'AT0', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC'
+                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'AT0', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC', 'ATTA7E4'
                 ],
                 offset: 0,
                 inStandbyMode: false,

--- a/app/www/components/cars/IONIQ_PHEV.vue
+++ b/app/www/components/cars/IONIQ_PHEV.vue
@@ -8,7 +8,7 @@
         data() {
             return {
                 initCMD: [
-                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'AT0', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC'
+                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'AT0', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC', 'ATTA7E4'
                 ],
                 offset: 0,
                 inStandbyMode: false,

--- a/app/www/components/cars/KONA_EV.vue
+++ b/app/www/components/cars/KONA_EV.vue
@@ -8,7 +8,7 @@
         data() {
             return {
                 initCMD: [
-                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC'
+                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC', 'ATTA7E4'
                 ],
                 offset: 0,
                 inStandbyMode: false,

--- a/app/www/components/cars/NIRO_EV.vue
+++ b/app/www/components/cars/NIRO_EV.vue
@@ -8,7 +8,7 @@
         data() {
             return {
                 initCMD: [
-                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC'
+                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC', 'ATTA7E4'
                 ],
                 offset: 0,
                 inStandbyMode: false,

--- a/app/www/components/cars/SOUL_EV.vue
+++ b/app/www/components/cars/SOUL_EV.vue
@@ -7,7 +7,7 @@
         data() {
             return {
                 initCMD: [
-                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'AT0', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC'
+                    'ATD', 'ATZ', 'ATE0', 'ATL0', 'ATS0', 'ATH1', 'AT0', 'ATSTFF', 'ATFE', 'ATSP6', 'ATCRA7EC', 'ATTA7E4'
                 ],
                 inStandbyMode: false,
                 offset: 0,


### PR DESCRIPTION
Untested, but ATTA should be the right command. This should reduce load on the bus and the dongle quite a bit.