### PR TITLE
Update value handling for e-golf

### DIFF
--- a/app/www/components/cars/E_GOLF.vue
+++ b/app/www/components/cars/E_GOLF.vue
@@ -19,7 +19,6 @@
                     '03221e3d55555555',
                     '0322028C55555555',
                     '0322744855555555',
-                    '0322189d55555555',
                     '03221e0f55555555',
                     '03221e0e55555555'
                 ]
@@ -80,11 +79,9 @@
                     } else if (self.currentCommand === 1) {
                         const firstDataByte = parseInt(data.slice(8, 10), 16); // fifth byte
                         const secondDataByte = parseInt(data.slice(10, 12), 16); // sixth byte
-                        const thirdDataByte = parseInt(data.slice(12, 14), 16); // seventh byte
-                        const fourthDataByte = parseInt(data.slice(14, 16), 16); // eigth byte
 
                         parsedData = {
-                            DC_BATTERY_CURRENT: ((firstDataByte * Math.pow(2, 32) + secondDataByte * Math.pow(2, 16) + thirdDataByte * Math.pow(2, 8) + fourthDataByte - 150000) / 100) * -1
+                            DC_BATTERY_CURRENT: ((firstDataByte * Math.pow(2, 8) + secondDataByte - 2044) / 4) * -1
                         };
                     } else if (self.currentCommand === 2) {
                         const socBMS = parseInt(data.slice(8,10), 16) / 2.5; // fifth byte
@@ -102,20 +99,13 @@
                             RAPID_CHARGE_PORT: mode === 6 ? 1 : 0
                         };
                     } else if (self.currentCommand === 4) {
-                        const firstDataByte = helper.parseSigned(data.slice(12,14)); // seventh byte
-                        const secondDataByte = Math.abs(helper.parseSigned(data.slice(14,16))); // eigth byte
-
-                        parsedData = {
-                            BATTERY_INLET_TEMPERATURE: (firstDataByte * Math.pow(2, 8) + secondDataByte) / 64
-                        };
-                    } else if (self.currentCommand === 5) {
                         const firstDataByte = helper.parseSigned(data.slice(8,10)); // fifth byte
                         const secondDataByte = Math.abs(helper.parseSigned(data.slice(10,12))); // sixth byte
 
                         parsedData = {
                             BATTERY_MIN_TEMPERATURE: (firstDataByte * Math.pow(2, 8) + secondDataByte) / 64
                         };
-                    } else if (self.currentCommand === 6) {
+                    } else if (self.currentCommand === 5) {
                         const firstDataByte = helper.parseSigned(data.slice(8,10)); // fifth byte
                         const secondDataByte = Math.abs(helper.parseSigned(data.slice(10,12))); // sixth byte
 


### PR DESCRIPTION
This pull request does two things for the e-golf value handling:

1) Fixes the DC_BATTERY_CURRENT calculation. The source of information is from OBD2 codes used for e-up here: https://www.goingelectric.de/wiki/Liste-der-OBD2-Codes/

2) Removes BATTERY_INLET_TEMPERATURE since the e-golf lacks a sensor for inlet temperature (no active heating or cooling)

Changes have been tested on my 2018 e-golf and seems to work well.